### PR TITLE
More clear name of lored reinforcement for /cti

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>vg.civcraft.mc.citadel</groupId>
 	<artifactId>Citadel</artifactId>
 	<packaging>jar</packaging>
-	<version>3.8.00</version>
+	<version>3.8.01</version>
 	<name>Citadel</name>
 	<url>https://github.com/Civcraft/Citadel</url>
 

--- a/src/vg/civcraft/mc/citadel/reinforcement/PlayerReinforcement.java
+++ b/src/vg/civcraft/mc/citadel/reinforcement/PlayerReinforcement.java
@@ -9,6 +9,7 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.material.Openable;
 
 import vg.civcraft.mc.citadel.Citadel;
@@ -26,6 +27,7 @@ public class PlayerReinforcement extends Reinforcement{
 	private static GroupManager gm;
 	private boolean isInsecure = false;
 	private ItemStack stack;
+	private String materialName;
 	
 	public PlayerReinforcement(Location loc, int health,
 			int creation, int acid, Group g, ItemStack stack) {
@@ -36,7 +38,12 @@ public class PlayerReinforcement extends Reinforcement{
 			gm = NameAPI.getGroupManager();
 		}
 		this.gid = g.getGroupId();
-	}	
+		
+		ItemMeta meta = this.stack.hasItemMeta() ? this.stack.getItemMeta(): null;
+		String lore = meta != null && meta.hasLore() && meta.getLore().size() > 0 ? meta.getLore().get(0): null;
+		
+		this.materialName = lore != null && lore.length() > 0 ? "\"" + lore + "\"": stack.getType().name();
+	}
 	
 	public boolean canBypass(Player p) {
 		checkValid();
@@ -217,7 +224,8 @@ public class PlayerReinforcement extends Reinforcement{
         } else {
             verb = "Reinforced";
         }
-        return String.format("%s %s with %s", verb, getHealthText(), getMaterial().name());
+        
+        return String.format("%s %s with %s", verb, getHealthText(), this.materialName);
     }
     
     private void checkValid(){


### PR DESCRIPTION
When block is reinforced by lored reinforcement then on /cti show quoted first line of lore instead of material name

This is especially useful when we have some reinforcements (like STONE) but with different lores and it is hard to understand what exactly reinforcement was applied on block