### PR TITLE
Return null instead of raise ReinforcemnetFortificationCancelException exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .project
 .settings/**
 .classpath
+.idea/*
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>vg.civcraft.mc.citadel</groupId>
 	<artifactId>Citadel</artifactId>
 	<packaging>jar</packaging>
-	<version>3.9.0</version>
+	<version>3.9.1</version>
 	<name>Citadel</name>
 	<url>https://github.com/Devoted/Citadel</url>
 

--- a/src/vg/civcraft/mc/citadel/Utility.java
+++ b/src/vg/civcraft/mc/citadel/Utility.java
@@ -58,7 +58,6 @@ public class Utility {
      * @param The ReinforcementType that is being reinforced on the block.
      * @param The ItemStack type of the block being placed (if CTF, null if CTR)
      * @return The PlayerReinforcement that comes from these parameters or null if certain checks failed.
-     * @throws ReinforcemnetFortificationCancelException
      */
     public static PlayerReinforcement createPlayerReinforcement(Player player, Group g, Block block,
             ReinforcementType type, ItemStack reinfMat) {
@@ -141,7 +140,7 @@ public class Utility {
         ReinforcementCreationEvent event = new ReinforcementCreationEvent(rein, block, player);
         Bukkit.getPluginManager().callEvent(event);
         if (event.isCancelled()) {
-            throw new ReinforcemnetFortificationCancelException();
+            return null;
         }
 		if (CitadelConfigManager.shouldLogReinforcement()) {
 			StringBuffer slb = new StringBuffer();

--- a/src/vg/civcraft/mc/citadel/listener/BlockListener.java
+++ b/src/vg/civcraft/mc/citadel/listener/BlockListener.java
@@ -547,16 +547,7 @@ public class BlockListener implements Listener {
 							g = GroupManager.getGroup(gName);
 						}
 						if (g != null) {
-							try {
-								createPlayerReinforcement(player, g,
-										block, type, null);
-							} catch (ReinforcemnetFortificationCancelException e) {
-								Citadel.getInstance()
-										.getLogger()
-										.log(Level.WARNING,
-												"ReinforcementFortificationCancelException occured in BlockListener, PlayerInteractEvent ",
-												e);
-							}
+							createPlayerReinforcement(player, g, block, type, null);
 						}
 					}
 				}
@@ -701,16 +692,7 @@ public class BlockListener implements Listener {
 						sendAndLog(player, ChatColor.RED,
 								"Cancelled reinforcement, crop would already be reinforced.");
 					} else {
-						try {
-							createPlayerReinforcement(player, state.getGroup(),
-									block, state.getReinforcementType(), null);
-						} catch (ReinforcemnetFortificationCancelException e) {
-							Citadel.getInstance()
-									.getLogger()
-									.log(Level.WARNING,
-											"ReinforcementFortificationCancelException occured in BlockListener, PlayerInteractEvent ",
-											e);
-						}
+						createPlayerReinforcement(player, state.getGroup(), block, state.getReinforcementType(), null);
 					}
 				} else if (reinforcement.canBypass(player)
 						|| (player.isOp() || player
@@ -747,12 +729,8 @@ public class BlockListener implements Listener {
 								ReinforcementCreationEvent event = new ReinforcementCreationEvent(reinforcement, block, player);
 								Bukkit.getPluginManager().callEvent(event);
 								if (!event.isCancelled()) {
-									try {
-										createPlayerReinforcement(player, state.getGroup(),	block, type, null);
+									if(createPlayerReinforcement(player, state.getGroup(),	block, type, null) != null) {
 										sendAndLog(player, ChatColor.GREEN, "Changed reinforcement type");
-									} catch (ReinforcemnetFortificationCancelException ex) {
-										Citadel.getInstance().getLogger().log(Level.WARNING,
-												"ReinforcementFortificationCancelException occured in BlockListener, PlayerInteractEvent ", ex);
 									}
 								}
 							}


### PR DESCRIPTION
Method Utility.createPlayerReinforcement now returns NULL if ReinforcementCreationEvent cancelled instead of raising ReinforcemnetFortificationCancelException  exception.

This is useful to avoid exceptions (and therefore to increase performance) when player's action to reinforce block in bastioned field is cancelled using new commonSettings.cancelReinInBastionField option from Bastion plugin.