### PR TITLE
Initial commit, adding in 100% return grace period

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -37,6 +37,8 @@ reinforcements:
   mature_time: 5
   acid_time: 30
   scale_amount: 1
+# grace period is in minutes, forced 100% return within that time if undamaged. Set to 0 to disable (default)
+  grace_period: 1
   lore:
   effect:
    type: ENCHANTMENT_TABLE

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>vg.civcraft.mc.citadel</groupId>
 	<artifactId>Citadel</artifactId>
 	<packaging>jar</packaging>
-	<version>3.9.1</version>
+	<version>3.9.2</version>
 	<name>Citadel</name>
 	<url>https://github.com/Devoted/Citadel</url>
 

--- a/src/vg/civcraft/mc/citadel/CitadelConfigManager.java
+++ b/src/vg/civcraft/mc/citadel/CitadelConfigManager.java
@@ -96,6 +96,10 @@ public class CitadelConfigManager {
 		return config.getStringList("reinforcements." + type + ".lore");
 	}
 	
+	public static int getGracePeriod(String type) {
+		return config.getInt("reinforcements." + type + ".grace_period", 0); // default disabled
+	}
+	
 	public static ReinforcementEffect getReinforcementEffect(String type){
 		Particle effect = null;
 		if (config.getString("reinforcements." + type + ".effect.type") != null) {

--- a/src/vg/civcraft/mc/citadel/Utility.java
+++ b/src/vg/civcraft/mc/citadel/Utility.java
@@ -562,8 +562,13 @@ public class Utility {
         if (reinforcement instanceof PlayerReinforcement) {
             PlayerReinforcement pr = (PlayerReinforcement)reinforcement;
             ReinforcementType material = ReinforcementType.getReinforcementType(pr.getStackRepresentation());
-			// RNG is [0,1) so <= would give chance of return if health is 0. Replaced with < alone to fix.
-            if (rng.nextDouble() < pr.getHealth() * material.getPercentReturn()) {
+            // Adds in grace period returns, where if set, allows in minute increments for players to change their minds with
+            // no loss. Only applies if the reinforcement is immature and undamaged
+            if ((material.getGracePeriod() > 0 && pr.getMaturationTime() > 0 && pr.getHealth() >= 1.0 &&  
+            			material.getMaturationTime() - timeUntilMature(pr) < material.getGracePeriod() ) ||
+        			// RNG is [0,1) so <= would give chance of return if health is 0. Replaced with < alone to fix.
+            		rng.nextDouble() < pr.getHealth() * material.getPercentReturn()) {
+            	
                 Location location = pr.getLocation();
                 if (player != null){
                     Inventory inv = player.getInventory();

--- a/src/vg/civcraft/mc/citadel/reinforcementtypes/ReinforcementType.java
+++ b/src/vg/civcraft/mc/citadel/reinforcementtypes/ReinforcementType.java
@@ -24,6 +24,7 @@ public class ReinforcementType {
 	private int maturationTime;
 	private int acidTime;
 	private int scale;
+	private int gracePeriod;
 	private ItemStack stack;
 	private ReinforcementEffect effect;
 	private Set <Material> allowedReinforceables;
@@ -35,7 +36,7 @@ public class ReinforcementType {
 	public ReinforcementType(Material mat, int amount, double percentReturn,
 			int returnValue, int hitpoints, int maturationTime, int acidTime,
 			int scale, List<String> lore, ReinforcementEffect effect, Set <Material> allowsReinforceables, 
-			Set <Material> disallowedReinforceables) {
+			Set <Material> disallowedReinforceables, int gracePeriod) {
 		this.mat = mat;
 		this.amount = amount;
 		this.percentReturn = percentReturn/100;
@@ -53,6 +54,7 @@ public class ReinforcementType {
 		types.put(stack, this);
 		this.allowedReinforceables = allowsReinforceables;
 		this.disallowedReinforceables = disallowedReinforceables;
+		this.gracePeriod = gracePeriod;
 	}
 	
 	public static void initializeReinforcementTypes(){
@@ -72,15 +74,17 @@ public class ReinforcementType {
 			Set <Material> reinforceableMats = CitadelConfigManager.parseMaterialList(reinforceableMatString);
 			List <String> unreinforceableMatString = CitadelConfigManager.getNonReinforceableMaterials(type);
 			Set <Material> nonReinforceableMats = CitadelConfigManager.parseMaterialList(unreinforceableMatString);
+			int gracePeriod = CitadelConfigManager.getGracePeriod(type);
 			new ReinforcementType(mat, amount, percentReturn, returnValue,
-					hitpoints, maturation, acid, maturation_scale, lore, effect, reinforceableMats, nonReinforceableMats);
+					hitpoints, maturation, acid, maturation_scale, lore, effect, reinforceableMats, nonReinforceableMats, gracePeriod);
 			if (CitadelConfigManager.shouldLogInternal()) {
 				Citadel.getInstance().getLogger().log(Level.INFO,
 						"Adding Reinforcement {0} with:\n  material {1} \n  amount {2} "
 								+ "\n  return rate {3} \n  return? {4} \n  health {5} \n  maturation {6} "
-								+ "\n  acid {7} \n  scaling {8} \n  lore: {9} \n  effect: \n {10}",
+								+ "\n  acid {7} \n  scaling {8} \n  lore: {9} \n  effect: \n {10} \n grace: {11}",
 						new Object[] { type, mat.toString(), amount, percentReturn, returnValue, hitpoints, maturation,
-								acid, maturation_scale, (lore != null ? String.join("   ", lore) : ""), (effect != null ? effect : "")});
+								acid, maturation_scale, (lore != null ? String.join("   ", lore) : ""), (effect != null ? effect : ""),
+								gracePeriod});
 			}
 		}
     }
@@ -175,5 +179,12 @@ public class ReinforcementType {
 		List<ReinforcementType> type = new ArrayList<ReinforcementType>();
 		type.addAll(types.values());
 		return type;
+	}
+	
+	/**
+	 * @return the time in minutes to "forgive" reinforcements and apply 100% return rate. Set to 0 to disable.
+	 */
+	public int getGracePeriod() {
+		return this.gracePeriod;
 	}
 }


### PR DESCRIPTION
Add "grace_period" to your individual reinforcement type definitions.

In minutes, defines the time where if you /ctb the block (and it has received no damage) you can get it back with 100% refund.

This will allow for complex reinforcements that are "permanent when set" -- 100% refund until damage or after a period of time, at which point, 0% refund (normal refund % applies) ... or any mix on the spectrum between "current state" and this new feature.

Note that default is "0" -- so no change is needed to existing configs, this is a safe upgrade. Tested. Will backport if requested.