### PR TITLE
 Don't turn /ctf off when attempting to switch reinforcement materials

### DIFF
--- a/src/vg/civcraft/mc/citadel/command/commands/Fortification.java
+++ b/src/vg/civcraft/mc/citadel/command/commands/Fortification.java
@@ -70,11 +70,13 @@ public class Fortification extends PlayerCommand{
 		}
 
 		PlayerState state = PlayerState.get(p);
-		if (ReinforcementMode.REINFORCEMENT_FORTIFICATION.equals(state.getMode())
-				&& (args.length == 0
-					|| (state.getGroup() != null
-						&& state.getGroup().getName() != null
-						&& state.getGroup().getName().equals(g.getName())))) {
+		boolean inFortificationMode = ReinforcementMode.REINFORCEMENT_FORTIFICATION.equals(state.getMode());
+		boolean noGroupSpecified = args.length == 0;
+		boolean noGroupChange = (
+			state.getGroup() != null
+			&& state.getGroup().getName() != null
+			&& state.getGroup().getName().equals(g.getName()));
+		if (inFortificationMode && (noGroupSpecified || noGroupChange)) {
 			Utility.sendAndLog(p, ChatColor.GREEN, state.getMode().name() + " has been disabled");
 			state.reset();
 			return true;

--- a/src/vg/civcraft/mc/citadel/command/commands/Fortification.java
+++ b/src/vg/civcraft/mc/citadel/command/commands/Fortification.java
@@ -76,18 +76,19 @@ public class Fortification extends PlayerCommand{
 			state.getGroup() != null
 			&& state.getGroup().getName() != null
 			&& state.getGroup().getName().equals(g.getName()));
-		if (inFortificationMode && (noGroupSpecified || noGroupChange)) {
+		ItemStack stack = p.getInventory().getItemInMainHand();
+		ReinforcementType reinType = ReinforcementType.getReinforcementType(stack);
+		boolean noMaterialChange = reinType != null && reinType.equals(state.getReinforcementType());
+		if (inFortificationMode && (noGroupSpecified || (noGroupChange && noMaterialChange))) {
 			Utility.sendAndLog(p, ChatColor.GREEN, state.getMode().name() + " has been disabled");
 			state.reset();
 			return true;
 		}
 
-		ItemStack stack = p.getInventory().getItemInMainHand();
 		if (stack.getType() == Material.AIR) {
 			Utility.sendAndLog(p, ChatColor.RED, "You need to be holding something to fortify with, try holding a stone block in your hand.");
 			return true;
 		}
-		ReinforcementType reinType = ReinforcementType.getReinforcementType(stack);
 		if (reinType == null) {
 			Utility.sendAndLog(p, ChatColor.RED, "You can't use the item in your hand to reinforce. Try using a stone block.");
 			return true;

--- a/src/vg/civcraft/mc/citadel/command/commands/Reinforce.java
+++ b/src/vg/civcraft/mc/citadel/command/commands/Reinforce.java
@@ -65,11 +65,13 @@ public class Reinforce extends PlayerCommand {
 		}
 
 		PlayerState state = PlayerState.get(p);
-		if (ReinforcementMode.REINFORCEMENT.equals(state.getMode())
-				&& (args.length == 0
-					|| (state.getGroup() != null
-						&& state.getGroup().getName() != null
-						&& state.getGroup().getName().equals(g.getName())))) {
+		boolean inReinforcementMode = ReinforcementMode.REINFORCEMENT.equals(state.getMode());
+		boolean noGroupSpecified = args.length == 0;
+		boolean noGroupChange = (
+			state.getGroup() != null
+			&& state.getGroup().getName() != null
+			&& state.getGroup().getName().equals(g.getName()));
+		if (inReinforcementMode && (noGroupSpecified || noGroupChange)) {
 			Utility.sendAndLog(p, ChatColor.GREEN, state.getMode().name() + " has been disabled");
 			state.reset();
 			return true;


### PR DESCRIPTION
Same as https://github.com/DevotedMC/Citadel/pull/42, just with reinforcement materials instead of groups.

Tested every case I could think of.